### PR TITLE
Fix syntax errors in POST variable array for email account management

### DIFF
--- a/php/add_email_account.php
+++ b/php/add_email_account.php
@@ -19,10 +19,10 @@ $postvars = array(
     'returncode' => $hst_returncode,
     'cmd' => $hst_command,
     'arg1' => $user,
-    'arg2' => $domain
-    'arg3' => $account
-    'arg4' => $password
-    'arg5' +> $quota // {5-unlimited}
+    'arg2' => $domain,
+    'arg3' => $account,
+    'arg4' => $password,
+    'arg5' => $quota // {5-unlimited}
 );
 
 // Send POST query via cURL

--- a/php/delete_email_account.php
+++ b/php/delete_email_account.php
@@ -19,7 +19,7 @@ $postvars = array(
     'returncode' => $hst_returncode,
     'cmd' => $hst_command,
     'arg1' => $user,
-    'arg2' => $domain
+    'arg2' => $domain,
     'arg3' => $account
 );
 


### PR DESCRIPTION
Fixing small syntax errors found when trying to use the examples.